### PR TITLE
feat(content): replace existing linkedin profile link with a valid public profile link

### DIFF
--- a/site/index.html
+++ b/site/index.html
@@ -42,7 +42,7 @@
     <h1 class="cover-heading custom-cover-heading">Jaylen Wimbish</h1>
     <p class="lead custom-lead">Software / DevOps Engineer, lover of all things tech. Enjoys nature, being a goofball, and spending time with friends and family.</p>
     <p class="lead">
-      <a href="https://www.linkedin.com/pub/jaylen-wimbish/3a/971/9b2" target="_blank" class="btn btn-lg btn-secondary button-margin-bottom"><i class="fa fa-linkedin-square fa-fw"></i>LinkedIn</a>
+      <a href="https://www.linkedin.com/in/jaylen-wimbish-9b29713a" target="_blank" class="btn btn-lg btn-secondary button-margin-bottom"><i class="fa fa-linkedin-square fa-fw"></i>LinkedIn</a>
       <a href="https://github.com/jaylenw" target="_blank" class="btn btn-lg btn-secondary button-margin-bottom"><i class="fa fa-github fa-fw"></i>GitHub</a>
     </p>
   </main>


### PR DESCRIPTION
### What does this PR do?

This PR includes changes that provides the correct public LinkedIn profile url. Prior to this, the link would prompt the visitor to sign in. The new link will show the public profile without requiring an individual to sign in to Linkedin.

### Which issue is related to this PR?

This issue is related to #3 

close #3